### PR TITLE
Float tests

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,8 @@ Checks:          'clang-analyzer-*,
                   modernize-*,
                   performance-*,
                   portability-*,
-                  readability-*,'
+                  readability-*,
+                  -readability-uppercase-literal-suffix'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/Generators/AllGenerators.h
+++ b/Generators/AllGenerators.h
@@ -1,2 +1,3 @@
 #pragma once
+#include "FloatGenerator.h"
 #include "IntGenerator.h"

--- a/Generators/FloatGenerator.h
+++ b/Generators/FloatGenerator.h
@@ -1,5 +1,5 @@
-#ifndef GENERATORS_INTGENERATOR_H
-#define GENERATORS_INTGENERATOR_H
+#ifndef GENERATORS_FLOATGENERATOR_H
+#define GENERATORS_FLOATGENERATOR_H
 
 #include <iostream>
 #include <random>
@@ -8,11 +8,13 @@
 #include "Logging.h"
 #include "Optional.h"
 
-class Generator_int {
+class Generator_float {
  public:
-  auto GenerateValue(GeneratorParameterStore& Parameters, bool IsUsed) -> int {
+  auto GenerateValue(GeneratorParameterStore& Parameters, bool IsUsed)
+      -> float {
     if (!IsUsed) {
-      Log(std::cout, LOG, "Int Generator was told its value will be ignored.");
+      Log(std::cout, LOG,
+          "Float Generator was told its value will be ignored.");
       std::cout << std::endl;
       return 1;
     }
@@ -21,32 +23,31 @@ class Generator_int {
     std::mt19937 RNG(Device());
 
     Optional<int> FetchedLowerBound =
-        Parameters.GetIntegerParameter(INT_LOWER_BOUND);
+        Parameters.GetIntegerParameter(FLOAT_LOWER_BOUND);
     Optional<int> FetchedUpperBound =
-        Parameters.GetIntegerParameter(INT_UPPER_BOUND);
+        Parameters.GetIntegerParameter(FLOAT_UPPER_BOUND);
 
-    int LowerBound;
-    int UpperBound;
+    float LowerBound;
+    float UpperBound;
 
     if (FetchedLowerBound.DataExists) {
       LowerBound = FetchedLowerBound.Data;
     }
     // Choose a sensible default in the absence of a parameter.
     else {
-      LowerBound = -1000;
+      LowerBound = -1000.0f;
     }
 
     if (FetchedUpperBound.DataExists) {
       UpperBound = FetchedUpperBound.Data;
     } else {
-      UpperBound = 1000;
+      UpperBound = 1000.0f;
     }
 
     Log(std::cout, LOG, "Upper and lower bounds are");
     Log(std::cout, VALUE_OUTPUT, std::to_string(UpperBound));
     Log(std::cout, VALUE_OUTPUT, std::to_string(LowerBound));
-    std::uniform_int_distribution<std::mt19937::result_type> Distribution(
-        LowerBound, UpperBound);
+    std::uniform_real_distribution<float> Distribution(LowerBound, UpperBound);
 
     int ToReturn = Distribution(RNG);
     Log(std::cout, LOG, "Generated value was");
@@ -58,4 +59,4 @@ class Generator_int {
   }
 };
 
-#endif /* GENERATORS_INTGENERATOR_H */
+#endif /* GENERATORS_FLOATGENERATOR_H */

--- a/Generators/FloatGenerator.h
+++ b/Generators/FloatGenerator.h
@@ -22,10 +22,10 @@ class Generator_float {
     std::random_device Device;
     std::mt19937 RNG(Device());
 
-    Optional<int> FetchedLowerBound =
-        Parameters.GetIntegerParameter(FLOAT_LOWER_BOUND);
-    Optional<int> FetchedUpperBound =
-        Parameters.GetIntegerParameter(FLOAT_UPPER_BOUND);
+    Optional<float> FetchedLowerBound =
+        Parameters.GetFloatParameter(FLOAT_LOWER_BOUND);
+    Optional<float> FetchedUpperBound =
+        Parameters.GetFloatParameter(FLOAT_UPPER_BOUND);
 
     float LowerBound;
     float UpperBound;
@@ -44,12 +44,13 @@ class Generator_float {
       UpperBound = 1000.0f;
     }
 
+    Log(std::cout, LOG, "Float generator invoked.");
     Log(std::cout, LOG, "Upper and lower bounds are");
     Log(std::cout, VALUE_OUTPUT, std::to_string(UpperBound));
     Log(std::cout, VALUE_OUTPUT, std::to_string(LowerBound));
     std::uniform_real_distribution<float> Distribution(LowerBound, UpperBound);
 
-    int ToReturn = Distribution(RNG);
+    float ToReturn = Distribution(RNG);
     Log(std::cout, LOG, "Generated value was");
     Log(std::cout, VALUE_OUTPUT, std::to_string(ToReturn));
 

--- a/Generators/GeneratorParameterStore.cpp
+++ b/Generators/GeneratorParameterStore.cpp
@@ -53,3 +53,33 @@ auto GeneratorParameterStore::GetIntegerParameter(
   // in which case the caller should take a reasonable default.
   return {0, false};
 }
+
+auto GeneratorParameterStore::GetFloatParameter(UnmaskedTestParameter Parameter)
+    -> Optional<float> {
+  // We wish to pull a temporary value before a permanent one.
+  // Check that the map contains the key, then see if that key leads to a useful
+  // int
+  if (TemporaryFloatParameters.find(Parameter) !=
+      TemporaryFloatParameters.end()) {
+    if (!TemporaryFloatParameters[Parameter].empty()) {
+      // For some reason there's no public interface to do these
+      // two steps in one line.
+      auto ToReturn = TemporaryFloatParameters[Parameter].front();
+      TemporaryFloatParameters[Parameter].pop();
+      Log(std::cout, LOG, "Fetched Temporary Parameter");
+      return {ToReturn, true};
+    }
+  }
+
+  if (FloatParameters.find(Parameter) != FloatParameters.end()) {
+    // Now we find out if there really is a permanent parameter.
+    if (FloatParameters[Parameter].DataExists) {
+      Log(std::cout, LOG, "Fetched Normal Parameter");
+      return FloatParameters[Parameter];
+    }
+  }
+
+  // Otherwise we simply signal back that there is no parameter available
+  // in which case the caller should take a reasonable default.
+  return {0.0f, false};
+}

--- a/Generators/GeneratorParameterStore.h
+++ b/Generators/GeneratorParameterStore.h
@@ -17,7 +17,8 @@ class GeneratorParameterStore {
 
   void ClearEverything();
 
-  Optional<int> GetIntegerParameter(UnmaskedTestParameter Parameter);
+  auto GetIntegerParameter(UnmaskedTestParameter Parameter) -> Optional<int>;
+  auto GetFloatParameter(UnmaskedTestParameter Parameter) -> Optional<float>;
 
   template <typename T>
   void PushParameter(UnmaskedTestParameter Param, T Value);
@@ -28,11 +29,19 @@ class GeneratorParameterStore {
  private:
   std::map<UnmaskedTestParameter, Optional<int>> IntegerParameters;
   std::map<UnmaskedTestParameter, std::queue<int>> TemporaryIntegerParameters;
+
+  std::map<UnmaskedTestParameter, Optional<float>> FloatParameters;
+  std::map<UnmaskedTestParameter, std::queue<float>> TemporaryFloatParameters;
 };
 
 const std::set<UnmaskedTestParameter> LegalIntegerParameters = {
     INT_LOWER_BOUND,
     INT_UPPER_BOUND,
+};
+
+const std::set<UnmaskedTestParameter> LegalFloatParameters = {
+    FLOAT_LOWER_BOUND,
+    FLOAT_UPPER_BOUND,
 };
 
 // WARNING: WEAK TYPING AHEAD
@@ -43,6 +52,8 @@ void GeneratorParameterStore::PushParameter(UnmaskedTestParameter Param,
                                             T Value) {
   if (SetContainsParameter(LegalIntegerParameters, Param)) {
     IntegerParameters[Param] = Optional<int>(Value, true);
+  } else if (SetContainsParameter(LegalFloatParameters, Param)) {
+    FloatParameters[Param] = Optional<float>(Value, true);
   } else {
     Log(std::cout, WARN,
         "Parameter was pushed to GeneratorParameterStore that it wasn't "
@@ -57,6 +68,8 @@ void GeneratorParameterStore::PushTempParameter(UnmaskedTestParameter Param,
                                                 T Value) {
   if (SetContainsParameter(LegalIntegerParameters, Param)) {
     TemporaryIntegerParameters[Param].emplace(int(Value));
+  } else if (SetContainsParameter(LegalFloatParameters, Param)) {
+    TemporaryFloatParameters[Param].emplace(float(Value));
   } else {
     Log(std::cout, WARN,
         "Temporary parameter was pushed to GeneratorParameterStore that it "

--- a/Generators/IntGenerator.h
+++ b/Generators/IntGenerator.h
@@ -42,6 +42,7 @@ class Generator_int {
       UpperBound = 1000;
     }
 
+    Log(std::cout, LOG, "Int generator invoked.");
     Log(std::cout, LOG, "Upper and lower bounds are");
     Log(std::cout, VALUE_OUTPUT, std::to_string(UpperBound));
     Log(std::cout, VALUE_OUTPUT, std::to_string(LowerBound));

--- a/SampleCXXProject/Calculations.h
+++ b/SampleCXXProject/Calculations.h
@@ -39,6 +39,17 @@ void TestSpecifications() {
                                  5.0f, 0, 0.0f, 1, 5.0f);
   UnmaskedAlwaysReturnsValueTest(std::function<float(float, float)>(&AddFloats),
                                  5.0f, 0, 0.0f, 1, 2.0f);
+  UnmaskedStabilisingSetTest(std::function<float(float, float)>(&AddFloats), 0,
+                             0.1f);
+
+  UnmaskedSetParameter(FLOAT_UPPER_BOUND, 10.0f);
+
+  UnmaskedSetTempParameter(FLOAT_LOWER_BOUND, -1.0f);
+  UnmaskedStabilisingSetTest(std::function<float(float, float)>(&AddFloats), 0,
+                             0.2f);
+
+  UnmaskedStabilisingSetTest(std::function<float(float, float)>(&AddFloats), 1,
+                             100.0f);
 }
 
 #endif /* SAMPLECXXPROJECT_CALCULATIONS_H */

--- a/SampleCXXProject/Calculations.h
+++ b/SampleCXXProject/Calculations.h
@@ -11,6 +11,8 @@ int LinearCombination(int A, int X, int B, int Y) { return A * X + B * Y; }
 
 int LinearCombinationWrong(int A, int X, int B, int Y) { return A + X + B * Y; }
 
+float AddFloats(float A, float B) { return A + B; }
+
 void TestSpecifications() {
   UnmaskedSetParameter(INT_LOWER_BOUND, 10);
   UnmaskedSetTempParameter(INT_UPPER_BOUND, 100);
@@ -30,6 +32,13 @@ void TestSpecifications() {
                                  0, 1, 0);
   UnmaskedAlwaysReturnsValueTest(std::function<int(int, int)>(&AddInts), 5, 0,
                                  0, 1, 0);
+
+  UnmaskedStabilisingSetTest(std::function<float(float, float)>(&AddFloats), 0,
+                             0.0f, 1, 0.0f);
+  UnmaskedAlwaysReturnsValueTest(std::function<float(float, float)>(&AddFloats),
+                                 5.0f, 0, 0.0f, 1, 5.0f);
+  UnmaskedAlwaysReturnsValueTest(std::function<float(float, float)>(&AddFloats),
+                                 5.0f, 0, 0.0f, 1, 2.0f);
 }
 
 #endif /* SAMPLECXXPROJECT_CALCULATIONS_H */

--- a/UserlandIncludes/UnmaskedTests.h
+++ b/UserlandIncludes/UnmaskedTests.h
@@ -9,6 +9,8 @@
 enum UnmaskedTestParameter {
   INT_LOWER_BOUND,
   INT_UPPER_BOUND,
+  FLOAT_LOWER_BOUND,
+  FLOAT_UPPER_BOUND,
 };
 
 template <typename... Ts>


### PR DESCRIPTION
Can now generate floating point values for tests. 

To keep parity with integers, parameters `FLOAT_UPPER_BOUND` and `FLOAT_LOWER_BOUND` have been added.

Relevant to #3 